### PR TITLE
k-fold_split optional argument to support headers in training folds.

### DIFF
--- a/themis/analyze.py
+++ b/themis/analyze.py
@@ -380,13 +380,14 @@ def drop_missing(systems_data):
     return systems_data
 
 
-def kfold_split(df, outdir, _folds = 5):
+def kfold_split(df, outdir, _folds = 5, _training_header = False):
     # Randomize the order of the input dataframe
     df = df.iloc[np.random.permutation(len(df))]
     df = df.reset_index(drop=True)
     foldSize = int(math.ceil(len(df) / float(_folds)))
     logger.info("Total records: " + str(len(df)))
     logger.info("Fold size: " + str(foldSize))
+    logger.info("Results written to output folder " + outdir)
 
     for x in range(0, _folds):
         fold_low = x*foldSize
@@ -399,7 +400,7 @@ def kfold_split(df, outdir, _folds = 5):
         train_df = df.drop(df.index[fold_low:fold_high])
 
         test_df.to_csv(os.path.join(outdir, 'Test' + str(x) + '.csv'), encoding='utf-8', index=False)
-        train_df.to_csv(os.path.join(outdir, 'Train' + str(x) + '.csv'), header=False, encoding='utf-8', index=False)
+        train_df.to_csv(os.path.join(outdir, 'Train' + str(x) + '.csv'), header=_training_header, encoding='utf-8', index=False)
 
         logger.info("--- Train_Fold_" + str(x) + ' size = ' + str(len(train_df)))
         logger.info("--- Test_Fold_" + str(x) + ' size = ' + str(len(test_df)))

--- a/themis/main.py
+++ b/themis/main.py
@@ -936,7 +936,9 @@ def util_command(subparsers):
     truncate.set_defaults(func=truncate_answers_handler)
     kfold_split = subparsers.add_parser("kfold-split", help="split a CSV file into K (= 5) Test and Train folds.")
     kfold_split.add_argument("file", type=CsvFileType(), help="CSV file")
-    kfold_split.add_argument("--output_directory", metavar="OUTPUT_DIRECTORY", type=str, default=".",
+    kfold_split.add_argument("--training-headers", action='store_true', default=False, dest="training_headers",
+                             help="flag: should training file headers be used? (default = False)")
+    kfold_split.add_argument("output_directory", metavar="OUTPUT_DIRECTORY", type=str, default=".",
                              help="output directory")
     kfold_split.set_defaults(func=kfold_split_handler)
 
@@ -972,7 +974,7 @@ def version_handler(_):
 
 
 def kfold_split_handler(args):
-    kfold_split(args.file, args.output_directory, 5)
+    kfold_split(args.file, args.output_directory, 5, args.training_headers)
 
 
 class HandlerClosure(object):


### PR DESCRIPTION
DCO 1.1 Signed-off-by: Stefan van der Stockt stefan.vanderstockt@gmail.com 

Changed kfold_split to use an optional boolean toggle to selct if the training folds should have a header row.  Default is False (ready for NLC).
This code can now be reused internally to perform k-fold data splits, in addition to being a stand-alone command in utils.
