### PR TITLE
Moved confidence_thresholds from plots.py to metrics.py

### DIFF
--- a/themis/metrics.py
+++ b/themis/metrics.py
@@ -1,3 +1,4 @@
+import numpy
 from themis import CONFIDENCE, CORRECT, FREQUENCY, IN_PURVIEW, logger
 
 
@@ -21,3 +22,10 @@ def questions_attempted(judgments, t):
     except ZeroDivisionError:
         logger.warning("No in-purview questions attempted at threshold level %0.3f" % t)
         return None
+
+
+def confidence_thresholds(judgments, add_max):
+    ts = judgments[CONFIDENCE].sort_values(ascending=False).unique()
+    if add_max:
+        ts = numpy.insert(ts, 0, numpy.Infinity)
+    return ts

--- a/themis/plot.py
+++ b/themis/plot.py
@@ -116,7 +116,7 @@ def questions_attempted(judgments, t):
         logger.warning("No in-purview questions attempted at threshold level %0.3f" % t)
         return None
 
-
+# TODO: Deprecated...use metrics.py
 def confidence_thresholds(judgments, add_max):
     ts = judgments[CONFIDENCE].sort_values(ascending=False).unique()
     if add_max:


### PR DESCRIPTION
DCO 1.1 Approved by: Stefan van der Stockt stefan.vanderstockt@gmail.com

Moved confidence_thresholds from plots.py to metrics.py to avoid circular imports.
