### PR TITLE
Calculate standard_confidence using either ranks or precision.

### DIFF
--- a/themis/analyze.py
+++ b/themis/analyze.py
@@ -20,7 +20,7 @@ SYSTEM = "System"
 ANSWERING_SYSTEM = "Answering System"
 
 
-def __standardize_confidence(system, method='precision'):
+def __standardize_confidence(system, method='rank'):
     """
     Takes a dataframe of a SINGLE SYSTEM with associated CONFIDENCE scores and standardizes the confidence
     values using the percentile in the list as the new confidence.
@@ -494,7 +494,7 @@ def voting_router(systems_data, system_names, voting_name):
         ts = confidence_thresholds(system, False)
         ps = [precision(system, t) for t in ts]
         qas = [questions_attempted(system, t) for t in ts]
-        system['pgc'] = __standardize_confidence(system)
+        system['pgc'] = __standardize_confidence(system, method='precision')
             #system.apply(lambda x: precision_grounded_confidence(ts, ps, qas, x[CONFIDENCE],
             #                                                                 method='precision_only'), axis=1)
 

--- a/themis/analyze.py
+++ b/themis/analyze.py
@@ -14,31 +14,10 @@ from metrics import precision
 from themis import (ANSWER, ANSWER_ID, CONFIDENCE, CORRECT, FREQUENCY,
                     IN_PURVIEW, QUESTION, CsvFileType, logger, to_csv)
 from themis.metrics import (confidence_thresholds, precision,
-                            precision_grounded_confidence, questions_attempted)
+                            precision_grounded_confidence, questions_attempted, __standardize_confidence)
 
 SYSTEM = "System"
 ANSWERING_SYSTEM = "Answering System"
-
-
-def __standardize_confidence(system, method='rank'):
-    """
-    Takes a dataframe of a SINGLE SYSTEM with associated CONFIDENCE scores and standardizes the confidence
-    values using the percentile in the list as the new confidence.
-
-    :param system: dataframe containing rows of a single system that has a CONFIDENCE column present.
-    :return: a Series containing the standardized confidence.
-    :rtype pandas.Series
-    """
-    if method == 'precision':
-        ts = confidence_thresholds(system, False)
-        ps = [precision(system, t) for t in ts]
-        qas = [questions_attempted(system, t) for t in ts]
-        return system.apply(lambda x: precision_grounded_confidence(ts, ps, qas, x[CONFIDENCE],
-                                                                   method='precision_only'), axis=1)
-    elif method == 'rank':
-        return system[CONFIDENCE].rank(pct=True)
-    else:
-        raise ValueError("Invalid method choice for standardize_confidence.")
 
 
 def corpus_statistics(corpus):

--- a/themis/metrics.py
+++ b/themis/metrics.py
@@ -45,3 +45,24 @@ def precision_grounded_confidence(ts, ps, qas, confidence, method='precision_onl
         return precision_t
     else:
         raise ValueError("Invalid method choice for precision_grounded_confidence.")
+
+
+def __standardize_confidence(system, method='rank'):
+    """
+    Takes a dataframe of a SINGLE SYSTEM with associated CONFIDENCE scores and standardizes the confidence
+    values using the percentile in the list as the new confidence.
+
+    :param system: dataframe containing rows of a single system that has a CONFIDENCE column present.
+    :return: a Series containing the standardized confidence.
+    :rtype pandas.Series
+    """
+    if method == 'precision':
+        ts = confidence_thresholds(system, False)
+        ps = [precision(system, t) for t in ts]
+        qas = [questions_attempted(system, t) for t in ts]
+        return system.apply(lambda x: precision_grounded_confidence(ts, ps, qas, x[CONFIDENCE],
+                                                                   method='precision_only'), axis=1)
+    elif method == 'rank':
+        return system[CONFIDENCE].rank(pct=True)
+    else:
+        raise ValueError("Invalid method choice for standardize_confidence.")

--- a/themis/metrics.py
+++ b/themis/metrics.py
@@ -40,5 +40,7 @@ def precision_grounded_confidence(ts, ps, qas, confidence, method='precision_onl
         return (1 - qa_t) * precision_t
     elif method == 'inverse_qa':
         return (1 - qa_t)
-    else:
+    elif method == 'precision_only':
         return precision_t
+    else:
+        raise ValueError("Invalid confidence standardization method selected.")

--- a/themis/metrics.py
+++ b/themis/metrics.py
@@ -44,4 +44,4 @@ def precision_grounded_confidence(ts, ps, qas, confidence, method='precision_onl
     elif method == 'precision_only':
         return precision_t
     else:
-        raise ValueError("Invalid confidence standardization method selected.")
+        return precision_t

--- a/themis/metrics.py
+++ b/themis/metrics.py
@@ -44,4 +44,4 @@ def precision_grounded_confidence(ts, ps, qas, confidence, method='precision_onl
     elif method == 'precision_only':
         return precision_t
     else:
-        return precision_t
+        raise ValueError("Invalid method choice for precision_grounded_confidence.")


### PR DESCRIPTION
DCO 1.1 Signed off by:  Stefan van der Stockt stefan.vanderstockt@gmail.com

Moved the method to metrics.py, and changed the parameters to decide which type of standardization to use.
